### PR TITLE
Make optional 'constraints' argument in createPeerConnection()

### DIFF
--- a/lib/rtc_peerconnection_factory.dart
+++ b/lib/rtc_peerconnection_factory.dart
@@ -5,7 +5,7 @@ import 'utils.dart';
 
 Future<RTCPeerConnection> createPeerConnection(
     Map<String, dynamic> configuration,
-    Map<String, dynamic> constraints) async {
+    [Map<String, dynamic> constraints = const {}]) async {
   MethodChannel channel = WebRTC.methodChannel();
 
   Map<String, dynamic> defaultConstraints = {


### PR DESCRIPTION
As we have default constraints in _createPeerConnection()_ we could make that arg optional in order to avoid passing empty map as following:

```dart
final pc = await createPeerConnection(configuration);
```

instead of: 
```dart
final pc = await createPeerConnection(configuration, {});
```